### PR TITLE
feat: add twitch funa system with sqlite identity model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ coverage/
 .env
 .env.local
 data/twitch-token.json
+data/*.db
+data/*.db-shm
+data/*.db-wal
 .DS_Store
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -151,25 +151,39 @@ src/
 - [Twitch](docs/apis/twitch.md)
 - [Philips Hue](docs/apis/hue.md)
 - [Discord](docs/apis/discord.md)
+- [Sistema de Funa](docs/funa-system.md)
 
 ## Nota
 
 `DISCORD_TOKEN` es opcional por ahora. Si no existe, el bot de Discord no se inicia.
 
+## Features Implementadas
+
+### ✅ `!luz <color>` (Twitch)
+Cambiar el color de las luces Philips Hue.
+
+### 🚧 `!funa <usuario>` (Twitch - en progreso)
+Contador de funas por usuario con persistencia SQLite. Detalles en [docs/funa-system.md](docs/funa-system.md).
+
 ## TODO (Roadmap)
 
-- Comando personalizado `!funa {nombreUsuario}`:
-  - Debe ser utilizable desde Discord y Twitch.
-  - Debe contar cuantas veces `{nombreUsuario}` fue mencionado en ese comando (cuantas veces fue funado).
-  - Debe responder con un mensaje tipo: `"{nombreUsuario} ha sido funado {cantidadFunas} veces"`.
-- Niveles de usuario:
+- **`!funa` (Twitch)** - EN PROGRESO
+  - ✅ Sistema de persistencia SQLite con identidades canónicas.
+  - ✅ Cooldown por comando por canal.
+  - ✅ Matching automático de nombres y búsqueda de similares.
+  - ⏳ Integración con Discord (reutilizará mismos servicios).
+  - ⏳ Comando de admin para unificar identidades manuales.
+
+- **Niveles de usuario**
   - Registrar cantidad de mensajes enviados por usuarios en Twitch y Discord.
   - Subir de nivel en base a cantidad de mensajes.
   - Considerar bonificadores de experiencia/subida para VIP y suscriptores.
   - En Discord, permitir excluir canales que no deben sumar niveles.
   - En Twitch y Discord, excluir mensajes que sean comandos (por ejemplo: `/play`, `!luz`, entre otros).
-- Dashboard de ranking de niveles.
-- Comando "preguntale a la IA":
+
+- **Dashboard de ranking de niveles**
+
+- **Comando "preguntale a la IA"**
   - En Twitch, con comando personalizado de uso exclusivo para moderadores.
   - Ejemplo: `!ia que paso un dia como hoy en 1954`.
   - La pregunta debe enviarse a un LLM configurable (por ejemplo Gemini).

--- a/docs/FUNA_QUICKSTART.md
+++ b/docs/FUNA_QUICKSTART.md
@@ -1,0 +1,82 @@
+# Guía Rápida: Sistema de Funa
+
+## Requisitos
+- Node.js 25.9.0+
+- Twitch bot token configurado en `.env`
+- Variables requeridas: `TWITCH_CLIENT_ID`, `TWITCH_CLIENT_SECRET`, `TWITCH_ACCESS_TOKEN`, `TWITCH_REFRESH_TOKEN`
+
+## Instalación
+```bash
+npm install  # Instala better-sqlite3 y dependencias
+```
+
+## Ejecutar Tests
+```bash
+npm test              # Suite completa
+npm test -- test/funa-system.test.js  # Solo tests de funa
+```
+
+## Ejecutar el Bot
+```bash
+npm run dev   # Modo development con watch
+npm start     # Ejecución normal
+```
+
+## Base de Datos
+- **Ubicación**: `data/io-bot.db` (se crea automáticamente)
+- **Migraciones**: Se ejecutan automáticamente al startup
+- **Schema**: 5 tablas + 6 índices. Ver `src/core/db/migrations/001_initial_schema.js`
+
+## Comando en Twitch
+```
+!funa <usuario>
+```
+
+**Ejemplo en chat**:
+```
+Usuario: !funa juanperez
+Bot: juanperez ha sido funado 5 veces 😅
+```
+
+## Cooldowns
+- `!funa`: 8 segundos por canal
+- El cooldown es global (aplica para cualquier usuario en ese canal)
+- Si intenta en cooldown: `"Espera un poco, acaban de usar esto. Intenta en 8s."`
+
+## Unificación de Identidades
+El sistema auto-matchea usuarios similares:
+- `juanperez` + `juan_perez` → mismo usuario (similitud > 0.85)
+- `juanperez` + `juancito` → usuarios diferentes (sin match claro)
+
+## Próximas Extensiones (No Implementadas)
+1. Discord: reutilizar mismos servicios
+2. Admin commands: `!finduser`, `!mergeuser`
+3. Niveles: sistema de XP por mensajes
+
+## Troubleshooting
+
+**Error: "no such column"**
+- Borrar `data/io-bot.db` y reiniciar (recrea schema)
+
+**Error: "UNIQUE constraint failed"**
+- Identidad duplicada, revisar identidades en DB
+
+**Tests fallando**
+- Correr `npm run lint` para validar sintaxis
+- Verificar `node --version` es 25.9.0+
+
+## Debugging
+```bash
+# Ver logs en memoria
+npm run dev 2>&1 | grep -i "funa\|identity\|cooldown"
+
+# Inspeccionar BD directamente
+sqlite3 data/io-bot.db ".schema"
+```
+
+## Archivos Clave
+- `src/core/services/IdentityService.js` - Matching de usuarios
+- `src/core/services/CooldownService.js` - Control de cooldowns  
+- `src/core/services/FunaService.js` - Eventos y conteos
+- `src/components/twitch/commands/FunaCommand.js` - Comando Twitch
+- `test/funa-system.test.js` - Tests

--- a/docs/funa-system.md
+++ b/docs/funa-system.md
@@ -1,0 +1,183 @@
+# Sistema de Funa
+
+## Descripción
+
+El sistema de funa permite que usuarios ejecuten el comando `!funa <usuario>` en Twitch para "funar" (mencionar de forma jocosa) a otros usuarios. El bot mantiene un contador de cuántas veces cada usuario ha sido funado.
+
+## Características
+
+### 1. Unificación de Identidades
+- El bot mantiene un modelo canónico de usuario (`users`) vinculado a identidades en diferentes plataformas (`identities`).
+- **Matching automático**: Cuando se detecta por primera vez un usuario, el sistema intenta hacer auto-match con usuarios similares en base a:
+  - Normalización de nombre (minúsculas, sin caracteres especiales, sin números al final).
+  - Similitud Levenshtein con umbral configurablemente (default 0.85).
+- **Match seguro**: Solo se auto-merge si hay exactamente un candidato por encima del umbral.
+- **Duplicados permitidos**: Si hay ambigüedad, se crea un nuevo usuario. Luego se pueden unificar manualmente.
+
+### 2. Cooldown por Comando
+- Cada comando tiene un cooldown configurable (ej: `funa` tiene 8 segundos).
+- El cooldown es **por canal y global** (no por usuario), para evitar spam grupal.
+- Si se intenta usar un comando en cooldown, el bot responde: `"Espera un poco, acaban de usar esto. Intenta en Xs."`
+- Configuración de cooldowns en `CooldownService.DEFAULT_COOLDOWNS`.
+
+### 3. Persistencia en SQLite
+- Base de datos robusta y ligera sin requerimientos de servidor externo.
+- Schema con migraciones automáticas al iniciar.
+- Preparada para escalar a niveles, dashboard y otras features.
+
+## Uso
+
+### Comando Básico
+
+```
+!funa <usuario>
+```
+
+**Ejemplo:**
+```
+!funa juanperez
+```
+
+**Respuesta:**
+```
+juanperez ha sido funado 5 veces 😅
+```
+
+## Arquitectura
+
+### Tablas Principales
+
+#### `users`
+- ID canónico de usuario en el sistema.
+- Se crea automáticamente para cada usuario único encontrado.
+
+#### `identities`
+- Mapeo entre plataforma + platform_user_id → user_id canónico.
+- Ejemplo: `(platform='twitch', platform_user_id='123456', user_id=1)`.
+- Almacena nombre de usuario y display name para trazabilidad.
+
+#### `funa_events`
+- Registro histórico de cada evento de funa.
+- Campos: actor (identidad), target (usuario), plataforma, timestamp.
+
+#### `command_cooldowns`
+- Control de cooldowns por comando y scope (ej: `command=funa, scope=channel#twitch:global`).
+- Almacena `last_used_at` en milisegundos desde epoch.
+
+### Servicios
+
+#### `IdentityService`
+```javascript
+// Obtener o crear identidad automáticamente
+const identity = identityService.getOrCreateIdentity(
+  'twitch', 
+  platformUserId,
+  username,
+  displayName
+);
+
+// Buscar usuarios similares
+const matches = identityService.findSimilarUsers('juanperez');
+
+// Unificar usuarios (merge manual)
+identityService.mergeUsers(sourceUserId, targetUserId, mergedBy, reason);
+```
+
+#### `CooldownService`
+```javascript
+// Verificar si comando está en cooldown
+const check = cooldownService.checkCooldown('funa', 'channel#twitch:global');
+if (check.onCooldown) {
+  console.log(`Espera ${check.remainingSeconds}s`);
+}
+
+// Registrar uso de comando
+cooldownService.recordUsage('funa', 'channel#twitch:global');
+```
+
+#### `FunaService`
+```javascript
+// Registrar un evento de funa
+funaService.recordFunaEvent(actorIdentityId, targetUserId, 'twitch');
+
+// Obtener conteo de funas de un usuario
+const count = funaService.getFunaCount(userId);
+
+// Obtener historial
+const history = funaService.getFunaHistory(userId, limit=10);
+
+// Estadísticas globales
+const stats = funaService.getFunaStats(); // { mostFunedUsers, topFuners }
+```
+
+### Comando para Twitch
+
+#### `FunaCommand`
+```javascript
+new FunaCommand({
+  identityService,
+  cooldownService,
+  funaService,
+  logger
+})
+```
+
+Flujo:
+1. Usuario ejecuta `!funa <target>`.
+2. Se verifica cooldown global del canal.
+3. Se obtiene/crea identidad del actor.
+4. Se busca usuario target por nombre (similar o exacto).
+5. Se registra evento en DB.
+6. Se retorna mensaje con conteo actualizado.
+
+## Configuración
+
+### Variables de Entorno
+- `DB_PATH`: Ruta de la base de datos (default: `data/io-bot.db`).
+- Cooldowns personalizados pueden configurarse en `CooldownService` constructor.
+
+### Threshold de Similitud
+El umbral de matching automático es configurable por defecto a `0.85` (escala 0-1):
+- `0.90+`: muy estricto, casi solo nombres iguales.
+- `0.85`: recomendado para capturar typos y variantes (juan vs juan_).
+- `0.75+`: más permisivo, captura más matches pero con riesgo de falsos positivos.
+
+## Extensión a Discord
+
+El diseño está pensado para reutilizar los mismos servicios en Discord:
+
+```javascript
+// En DiscordBot, igual que en TwitchBot:
+const discordFunaCommand = new FunaCommand({
+  identityService, // compartido
+  cooldownService, // compartido
+  funaService,    // compartido
+  logger
+});
+
+// Al recibir mensajes en Discord:
+identityService.getOrCreateIdentity('discord', userId, username, displayName);
+// La identidad se unificará automáticamente si hay match con Twitch.
+```
+
+## Roadmap Futuro
+
+- Modificadores de experiencia para VIP/suscriptores.
+- Dashboard de ranking con gráficos.
+- Sistema de niveles basado en contadores.
+- Integración con IA para respuestas dinámicas.
+- Match manual vía comando de admin.
+
+## Testing
+
+Ejecutar tests del sistema de funa:
+```bash
+npm test -- test/funa-system.test.js
+```
+
+Tests cubiertos:
+- Creación y matching automático de identidades.
+- Búsqueda de usuarios similares.
+- Gestión de cooldowns.
+- Registro y conteo de eventos de funa.
+- Estadísticas globales.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@twurple/auth": "^8.1.3",
         "@twurple/chat": "^8.1.3",
         "axios": "^1.9.0",
+        "better-sqlite3": "^12.9.0",
         "discord.js": "^14.18.0",
         "dotenv": "^16.5.0",
         "pino": "^9.7.0",
@@ -26,7 +27,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=25.9.0"
       }
     },
     "node_modules/@d-fischer/cache-decorators": {
@@ -1705,6 +1706,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1714,6 +1769,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cac": {
@@ -1792,6 +1871,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1882,6 +1967,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1890,6 +1990,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1906,6 +2015,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/discord-api-types": {
@@ -1974,7 +2092,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2267,6 +2384,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2342,6 +2468,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2416,6 +2548,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2476,6 +2614,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2571,6 +2715,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2607,6 +2771,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/ircv3": {
       "version": "0.33.1",
@@ -2828,6 +3004,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2845,11 +3033,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2877,12 +3070,30 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -2897,7 +3108,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3137,6 +3347,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3192,7 +3429,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3214,6 +3450,44 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -3279,6 +3553,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -3304,6 +3598,18 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3334,6 +3640,51 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
@@ -3377,6 +3728,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3414,6 +3774,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thread-stream": {
@@ -3498,6 +3886,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3535,6 +3935,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",
@@ -3754,7 +4160,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@twurple/auth": "^8.1.3",
     "@twurple/chat": "^8.1.3",
     "axios": "^1.9.0",
+    "better-sqlite3": "^12.9.0",
     "discord.js": "^14.18.0",
     "dotenv": "^16.5.0",
     "pino": "^9.7.0",

--- a/src/app/Application.js
+++ b/src/app/Application.js
@@ -1,20 +1,52 @@
 import { loadConfig } from '../core/config/env.js';
 import { createLogger } from '../core/logger/logger.js';
 import { CommandRegistry } from '../core/commands/CommandRegistry.js';
+import { DatabaseManager } from '../core/db/Database.js';
 import { HueApiClient } from '../components/hue/HueApiClient.js';
 import { HueLightService } from '../components/hue/HueLightService.js';
 import { LightCommand } from '../components/twitch/commands/LightCommand.js';
+import { FunaCommand } from '../components/twitch/commands/FunaCommand.js';
 import { TwitchBot } from '../components/twitch/TwitchBot.js';
 import { DiscordBot } from '../components/discord/DiscordBot.js';
+import { IdentityService } from '../core/services/IdentityService.js';
+import { CooldownService } from '../core/services/CooldownService.js';
+import { FunaService } from '../core/services/FunaService.js';
 
 export class Application {
   constructor() {
     this.config = loadConfig();
     this.logger = createLogger(this.config.logLevel);
+    this.databaseManager = null;
     this.instances = [];
   }
 
   async start() {
+    // Inicializar base de datos
+    this.databaseManager = new DatabaseManager({
+      dbPath: 'data/io-bot.db',
+      logger: this.logger,
+    });
+    await this.databaseManager.initialize();
+    const db = this.databaseManager.getDb();
+
+    // Inicializar servicios de identidad, cooldown y funa
+    const identityService = new IdentityService({
+      db,
+      logger: this.logger,
+      similarityThreshold: 0.85,
+    });
+
+    const cooldownService = new CooldownService({
+      db,
+      logger: this.logger,
+    });
+
+    const funaService = new FunaService({
+      db,
+      logger: this.logger,
+    });
+
+    // Inicializar Hue
     const hueApiClient = new HueApiClient({
       bridgeIp: this.config.hue.bridgeIp,
       appKey: this.config.hue.appKey,
@@ -29,13 +61,23 @@ export class Application {
       logger: this.logger,
     });
 
+    // Registrar comandos
     const commandRegistry = new CommandRegistry();
     commandRegistry.register(
       new LightCommand({
         hueLightService,
       }),
     );
+    commandRegistry.register(
+      new FunaCommand({
+        identityService,
+        cooldownService,
+        funaService,
+        logger: this.logger,
+      }),
+    );
 
+    // Inicializar bots
     const twitchBot = new TwitchBot({
       clientId: this.config.twitch.clientId,
       clientSecret: this.config.twitch.clientSecret,
@@ -62,11 +104,14 @@ export class Application {
   }
 
   async stop() {
-    if (this.instances.length === 0) {
-      return;
+    if (this.instances.length > 0) {
+      await Promise.all(this.instances.map((instance) => instance.stop()));
     }
 
-    await Promise.all(this.instances.map((instance) => instance.stop()));
+    if (this.databaseManager) {
+      await this.databaseManager.close();
+    }
+
     this.logger.info('IO-Bot V2 detenido');
   }
 }

--- a/src/components/twitch/TwitchBot.js
+++ b/src/components/twitch/TwitchBot.js
@@ -37,8 +37,8 @@ export class TwitchBot {
       channels: this.channels,
     });
 
-    this.chatClient.onMessage(async (channel, user, text) => {
-      await this.#onMessage(channel, user, text);
+    this.chatClient.onMessage(async (channel, user, text, msg) => {
+      await this.#onMessage(channel, user, text, msg);
     });
 
     await this.chatClient.connect();
@@ -84,7 +84,7 @@ export class TwitchBot {
     return authProvider;
   }
 
-  async #onMessage(channel, user, text) {
+  async #onMessage(channel, user, text, msg) {
     if (!text.startsWith(this.commandPrefix)) {
       return;
     }
@@ -97,9 +97,15 @@ export class TwitchBot {
     }
 
     try {
+      const userContext = {
+        id: msg?.userInfo?.userId ?? user,
+        username: user,
+        displayName: msg?.userInfo?.displayName ?? user,
+      };
+
       const result = await this.commandRegistry.execute(commandName.toLowerCase(), {
         channel,
-        user,
+        user: userContext,
         text,
         args,
       });

--- a/src/components/twitch/commands/FunaCommand.js
+++ b/src/components/twitch/commands/FunaCommand.js
@@ -1,0 +1,87 @@
+export class FunaCommand {
+  constructor({
+    identityService,
+    cooldownService,
+    funaService,
+    logger,
+  }) {
+    this.name = 'funa';
+    this.identityService = identityService;
+    this.cooldownService = cooldownService;
+    this.funaService = funaService;
+    this.logger = logger;
+  }
+
+  async execute(context) {
+    const { channel, user, args, text } = context;
+
+    // Validar que se pasó un nombre de usuario
+    if (!args || args.length === 0) {
+      return 'Uso: !funa <usuario>';
+    }
+
+    const targetUsername = args[0].replace(/^@+/, '');
+
+    // Verificar cooldown por canal (scope global)
+    const scopeKey = `${channel}:global`;
+    const cooldownCheck = this.cooldownService.checkCooldown(this.name, scopeKey);
+
+    if (cooldownCheck.onCooldown) {
+      return `Espera un poco, acaban de usar esto. Intenta en ${cooldownCheck.remainingSeconds}s.`;
+    }
+
+    try {
+      // Obtener o crear identidad del actor (quien ejecuta el comando)
+      const actorIdentity = this.identityService.getOrCreateIdentity(
+        'twitch',
+        user.id,
+        user.username,
+        user.displayName,
+      );
+
+      // Buscar usuario target: usar registro existente o crear uno pendiente.
+      let targetUser = null;
+      const candidateMatches = this.identityService.findSimilarUsers(targetUsername);
+
+      if (candidateMatches.length > 0) {
+        // Tomar el mejor match
+        targetUser = candidateMatches[0];
+      } else {
+        const unresolvedIdentity = this.identityService.getOrCreateUnresolvedIdentity(
+          'twitch',
+          targetUsername,
+        );
+
+        targetUser = {
+          user_id: unresolvedIdentity.user_id,
+          username: unresolvedIdentity.username,
+        };
+      }
+
+      // Registrar evento de funa
+      this.funaService.recordFunaEvent(
+        actorIdentity.id,
+        targetUser.user_id,
+        'twitch',
+        text, // sourceMessageId
+      );
+
+      // Obtener conteo actualizado
+      const funaCount = this.funaService.getFunaCount(targetUser.user_id);
+
+      // Registrar uso de comando (actualizar cooldown)
+      this.cooldownService.recordUsage(this.name, scopeKey);
+
+      return `${targetUser.username} ha sido funado ${funaCount} veces 😅`;
+    } catch (error) {
+      this.logger?.error({
+        command: this.name,
+        user: user?.displayName ?? user?.username,
+        targetUsername,
+        error: error.message,
+      }, 'Error ejecutando comando funa');
+
+      return 'Hubo un error al procesar el funa. Intenta de nuevo.';
+    }
+  }
+}

--- a/src/core/db/Database.js
+++ b/src/core/db/Database.js
@@ -1,0 +1,79 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export class DatabaseManager {
+  constructor({ dbPath = 'data/io-bot.db', logger } = {}) {
+    this.dbPath = dbPath;
+    this.logger = logger;
+    this.db = null;
+  }
+
+  async initialize() {
+    // Asegurar que el directorio existe
+    const dir = path.dirname(this.dbPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Abrir conexión
+    this.db = new Database(this.dbPath);
+    this.db.pragma('journal_mode = WAL');
+
+    // Ejecutar migraciones
+    await this.#runMigrations();
+
+    this.logger?.info(`Base de datos inicializada en ${this.dbPath}`);
+  }
+
+  async #runMigrations() {
+    // Crear tabla de migraciones si no existe
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS migrations (
+        id INTEGER PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        executed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    const migrationsDir = path.join(__dirname, 'migrations');
+
+    // Obtener archivos de migración
+    const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith('.js'));
+
+    for (const file of files) {
+      const migrationName = path.basename(file, '.js');
+      const alreadyRun = this.db
+        .prepare('SELECT COUNT(*) as count FROM migrations WHERE name = ?')
+        .get(migrationName);
+
+      if (alreadyRun.count === 0) {
+        const migrationPath = path.join(migrationsDir, file);
+        const { default: migration } = await import(`file://${migrationPath}`);
+
+        this.logger?.info(`Ejecutando migración: ${migrationName}`);
+        migration(this.db);
+
+        this.db.prepare('INSERT INTO migrations (name) VALUES (?)').run(migrationName);
+        this.logger?.info(`Migración completada: ${migrationName}`);
+      }
+    }
+  }
+
+  getDb() {
+    if (!this.db) {
+      throw new Error('Database no ha sido inicializada. Llama a initialize() primero.');
+    }
+    return this.db;
+  }
+
+  async close() {
+    if (this.db) {
+      this.db.close();
+      this.logger?.info('Base de datos cerrada');
+    }
+  }
+}

--- a/src/core/db/migrations/001_initial_schema.js
+++ b/src/core/db/migrations/001_initial_schema.js
@@ -1,0 +1,77 @@
+export default function (db) {
+  // Tabla de usuarios canónicos
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  // Tabla de identidades (usuario de Twitch/Discord vinculado a un user_id)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS identities (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      platform TEXT NOT NULL,
+      platform_user_id TEXT NOT NULL,
+      username TEXT NOT NULL,
+      display_name TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES users(id),
+      UNIQUE(platform, platform_user_id)
+    )
+  `);
+
+  // Tabla de eventos de funa
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS funa_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_identity_id INTEGER NOT NULL,
+      target_user_id INTEGER NOT NULL,
+      platform TEXT NOT NULL,
+      source_message_id TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (actor_identity_id) REFERENCES identities(id),
+      FOREIGN KEY (target_user_id) REFERENCES users(id)
+    )
+  `);
+
+  // Tabla de cooldowns de comandos
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS command_cooldowns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      command_name TEXT NOT NULL,
+      scope_key TEXT NOT NULL,
+      last_used_at DATETIME NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(command_name, scope_key)
+    )
+  `);
+
+  // Tabla de auditoría de merges de identidades
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS identity_merges (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_user_id INTEGER NOT NULL,
+      target_user_id INTEGER NOT NULL,
+      merged_by TEXT,
+      reason TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (source_user_id) REFERENCES users(id),
+      FOREIGN KEY (target_user_id) REFERENCES users(id)
+    )
+  `);
+
+  // Crear índices para queries frecuentes
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_identities_user_id ON identities(user_id);
+    CREATE INDEX IF NOT EXISTS idx_identities_platform_user_id ON identities(platform, platform_user_id);
+    CREATE INDEX IF NOT EXISTS idx_funa_events_target_user_id ON funa_events(target_user_id);
+    CREATE INDEX IF NOT EXISTS idx_funa_events_actor_identity_id ON funa_events(actor_identity_id);
+    CREATE INDEX IF NOT EXISTS idx_funa_events_created_at ON funa_events(created_at);
+    CREATE INDEX IF NOT EXISTS idx_command_cooldowns_command_name ON command_cooldowns(command_name);
+  `);
+}

--- a/src/core/services/CooldownService.js
+++ b/src/core/services/CooldownService.js
@@ -1,0 +1,84 @@
+export class CooldownService {
+  // Configuración de cooldowns por comando (en segundos)
+  static DEFAULT_COOLDOWNS = {
+    luz: 5,
+    funa: 8,
+    ia: 20,
+  };
+
+  constructor({ db, logger, cooldownConfig = {} }) {
+    this.db = db;
+    this.logger = logger;
+    this.cooldownConfig = {
+      ...CooldownService.DEFAULT_COOLDOWNS,
+      ...cooldownConfig,
+    };
+  }
+
+  /**
+   * Obtiene el cooldown configurado para un comando.
+   */
+  getCooldownDuration(commandName) {
+    return this.cooldownConfig[commandName] || 5; // Default 5 segundos
+  }
+
+  /**
+   * Chequea si un comando está en cooldown.
+   * Retorna { onCooldown: boolean, remainingSeconds: number }
+   */
+  checkCooldown(commandName, scopeKey) {
+    const cooldownDuration = this.getCooldownDuration(commandName);
+    const now = Date.now();
+
+    const record = this.db
+      .prepare('SELECT last_used_at FROM command_cooldowns WHERE command_name = ? AND scope_key = ?')
+      .get(commandName, scopeKey);
+
+    if (!record) {
+      return {
+        onCooldown: false,
+        remainingSeconds: 0,
+      };
+    }
+
+    const lastUsedTime = Number(record.last_used_at);
+    const elapsedSeconds = (now - lastUsedTime) / 1000;
+    const remainingSeconds = Math.max(0, cooldownDuration - elapsedSeconds);
+
+    return {
+      onCooldown: remainingSeconds > 0,
+      remainingSeconds: Math.ceil(remainingSeconds),
+    };
+  }
+
+  /**
+   * Registra el uso de un comando (actualiza timestamp de last_used_at).
+   */
+  recordUsage(commandName, scopeKey) {
+    const now = Date.now();
+    const stmt = this.db.prepare(`
+      INSERT INTO command_cooldowns (command_name, scope_key, last_used_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(command_name, scope_key) 
+      DO UPDATE SET last_used_at = ?, updated_at = ?
+    `);
+
+    stmt.run(commandName, scopeKey, now, now, now, now, now);
+  }
+
+  /**
+   * Limpia cooldown de un comando para un scope (útil para testing o override).
+   */
+  clearCooldown(commandName, scopeKey) {
+    this.db
+      .prepare('DELETE FROM command_cooldowns WHERE command_name = ? AND scope_key = ?')
+      .run(commandName, scopeKey);
+  }
+
+  /**
+   * Limpia todos los cooldowns (útil para reset completo).
+   */
+  clearAllCooldowns() {
+    this.db.exec('DELETE FROM command_cooldowns');
+  }
+}

--- a/src/core/services/FunaService.js
+++ b/src/core/services/FunaService.js
@@ -1,0 +1,106 @@
+export class FunaService {
+  constructor({ db, logger }) {
+    this.db = db;
+    this.logger = logger;
+  }
+
+  /**
+   * Registra un evento de funa: actor funea a target.
+   */
+  recordFunaEvent(actorIdentityId, targetUserId, platform, sourceMessageId = null) {
+    const stmt = this.db.prepare(`
+      INSERT INTO funa_events (actor_identity_id, target_user_id, platform, source_message_id, created_at)
+      VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+    `);
+
+    const result = stmt.run(actorIdentityId, targetUserId, platform, sourceMessageId);
+
+    this.logger?.info({
+      actorIdentityId,
+      targetUserId,
+      platform,
+    }, 'Evento de funa registrado');
+
+    return result.lastInsertRowid;
+  }
+
+  /**
+   * Obtiene el conteo de funas de un usuario.
+   */
+  getFunaCount(targetUserId) {
+    const result = this.db
+      .prepare('SELECT COUNT(*) as count FROM funa_events WHERE target_user_id = ?')
+      .get(targetUserId);
+
+    return result.count;
+  }
+
+  /**
+   * Obtiene el histórico de funas de un usuario.
+   * Retorna lista con información del actor, fecha, plataforma, etc.
+   */
+  getFunaHistory(targetUserId, limit = 10) {
+    return this.db
+      .prepare(`
+        SELECT 
+          fe.id,
+          fe.created_at,
+          fe.platform,
+          i.username as actor_username,
+          i.display_name as actor_display_name
+        FROM funa_events fe
+        JOIN identities i ON fe.actor_identity_id = i.id
+        WHERE fe.target_user_id = ?
+        ORDER BY fe.created_at DESC
+        LIMIT ?
+      `)
+      .all(targetUserId, limit);
+  }
+
+  /**
+   * Obtiene estadísticas de funas: quién más fune, quién es más funado, etc.
+   */
+  getFunaStats() {
+    const mostFunedUsers = this.db
+      .prepare(`
+        SELECT 
+          u.id,
+          COUNT(*) as funa_count,
+          GROUP_CONCAT(i.username) as usernames
+        FROM funa_events fe
+        JOIN users u ON fe.target_user_id = u.id
+        JOIN identities i ON u.id = i.user_id
+        GROUP BY u.id
+        ORDER BY funa_count DESC
+        LIMIT 10
+      `)
+      .all();
+
+    const topFuners = this.db
+      .prepare(`
+        SELECT 
+          i.id,
+          i.username,
+          i.display_name,
+          COUNT(*) as funa_count
+        FROM funa_events fe
+        JOIN identities i ON fe.actor_identity_id = i.id
+        GROUP BY i.id
+        ORDER BY funa_count DESC
+        LIMIT 10
+      `)
+      .all();
+
+    return {
+      mostFunedUsers,
+      topFuners,
+    };
+  }
+
+  /**
+   * Limpia todos los eventos de funa (útil para testing).
+   */
+  clearAllEvents() {
+    this.db.exec('DELETE FROM funa_events');
+  }
+}

--- a/src/core/services/IdentityService.js
+++ b/src/core/services/IdentityService.js
@@ -1,0 +1,210 @@
+import { levenshteinDistance } from '../../shared/string-utils.js';
+
+export class IdentityService {
+  constructor({ db, logger, similarityThreshold = 0.85 }) {
+    this.db = db;
+    this.logger = logger;
+    this.similarityThreshold = similarityThreshold;
+  }
+
+  /**
+   * Obtiene o crea una identidad para un usuario de plataforma.
+   * Intenta hacer match automático con usuarios existentes si el nombre es similar.
+   */
+  getOrCreateIdentity(platform, platformUserId, username, displayName) {
+    // Buscar identidad existente
+    const existing = this.db
+      .prepare('SELECT * FROM identities WHERE platform = ? AND platform_user_id = ?')
+      .get(platform, platformUserId);
+
+    if (existing) {
+      return existing;
+    }
+
+    // No existe, intentar matching automático
+    const normalizedUsername = this.#normalizeUsername(username);
+    const candidates = this.#findCandidateMatches(normalizedUsername);
+
+    let targetUserId;
+
+    if (candidates.length === 1 && candidates[0].similarity >= this.similarityThreshold) {
+      // Match automático seguro
+      targetUserId = candidates[0].user_id;
+      this.logger?.info({
+        platform,
+        platformUserId,
+        username,
+        targetUserId,
+        similarity: candidates[0].similarity,
+      }, 'Auto-matching de identidad');
+    } else {
+      // Sin match claro, crear nuevo usuario
+      const newUser = this.db.prepare('INSERT INTO users (created_at, updated_at) VALUES (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)').run();
+      targetUserId = newUser.lastInsertRowid;
+    }
+
+    // Crear identidad
+    const stmt = this.db.prepare(`
+      INSERT INTO identities (user_id, platform, platform_user_id, username, display_name, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `);
+
+    stmt.run(targetUserId, platform, platformUserId, username, displayName || username);
+
+    const identity = this.db
+      .prepare('SELECT * FROM identities WHERE platform = ? AND platform_user_id = ?')
+      .get(platform, platformUserId);
+
+    return identity;
+  }
+
+  /**
+   * Crea (o recupera) una identidad "pendiente" basada solo en username.
+   * Sirve cuando el usuario target no se ha visto aun en chat y no tenemos userId real.
+   */
+  getOrCreateUnresolvedIdentity(platform, username) {
+    const normalized = this.#normalizeUsername(username);
+
+    if (!normalized) {
+      throw new Error('Username invalido para crear identidad pendiente');
+    }
+
+    const unresolvedPlatformUserId = `unresolved:${normalized}`;
+    return this.getOrCreateIdentity(platform, unresolvedPlatformUserId, username, username);
+  }
+
+  /**
+   * Encuentra usuarios similares a un nombre dado.
+   * Devuelve lista de candidates con score de similitud.
+   */
+  findSimilarUsers(username) {
+    const normalized = this.#normalizeUsername(username);
+    const allIdentities = this.db
+      .prepare('SELECT DISTINCT user_id, username FROM identities ORDER BY user_id')
+      .all();
+
+    const candidates = [];
+
+    for (const identity of allIdentities) {
+      const normalizedExisting = this.#normalizeUsername(identity.username);
+      const similarity = this.#calculateSimilarity(normalized, normalizedExisting);
+
+      if (similarity >= this.similarityThreshold) {
+        candidates.push({
+          user_id: identity.user_id,
+          username: identity.username,
+          similarity,
+        });
+      }
+    }
+
+    return candidates.sort((a, b) => b.similarity - a.similarity);
+  }
+
+  /**
+   * Merge manual: une source_user_id con target_user_id.
+   * Todas las identidades de source apuntan a target, y source es marcado como merged.
+   */
+  mergeUsers(sourceUserId, targetUserId, mergedBy = 'system', reason = '') {
+    if (sourceUserId === targetUserId) {
+      throw new Error('No se puede mergear un usuario consigo mismo');
+    }
+
+    // Reasignar identidades de source a target
+    const stmt = this.db.prepare('UPDATE identities SET user_id = ? WHERE user_id = ?');
+    stmt.run(targetUserId, sourceUserId);
+
+    // Registrar merge en auditoría
+    this.db
+      .prepare('INSERT INTO identity_merges (source_user_id, target_user_id, merged_by, reason, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)')
+      .run(sourceUserId, targetUserId, mergedBy, reason);
+
+    this.logger?.info({
+      sourceUserId,
+      targetUserId,
+      mergedBy,
+      reason,
+    }, 'Identidades unificadas');
+  }
+
+  /**
+   * Obtiene todas las identidades de un usuario.
+   */
+  getIdentitiesByUserId(userId) {
+    return this.db
+      .prepare('SELECT * FROM identities WHERE user_id = ? ORDER BY platform, created_at')
+      .all(userId);
+  }
+
+  /**
+   * Obtiene información completa de un usuario incluyendo todas sus identidades.
+   */
+  getUserWithIdentities(userId) {
+    const user = this.db.prepare('SELECT * FROM users WHERE id = ?').get(userId);
+
+    if (!user) {
+      return null;
+    }
+
+    const identities = this.getIdentitiesByUserId(userId);
+
+    return {
+      ...user,
+      identities,
+    };
+  }
+
+  /**
+   * Normaliza un nombre de usuario: minúsculas, sin caracteres especiales, etc.
+   */
+  #normalizeUsername(username) {
+    const safeUsername = typeof username === 'string' ? username : '';
+
+    return safeUsername
+      .toLowerCase()
+      .trim()
+      .replace(/[_.-]/g, '')
+      .replace(/\d+$/, ''); // Remove trailing digits
+  }
+
+  /**
+   * Encuentra candidatos potenciales para match.
+   */
+  #findCandidateMatches(normalizedUsername) {
+    const allIdentities = this.db
+      .prepare('SELECT DISTINCT user_id, username FROM identities')
+      .all();
+
+    const candidates = [];
+
+    for (const identity of allIdentities) {
+      const normalized = this.#normalizeUsername(identity.username);
+      const similarity = this.#calculateSimilarity(normalizedUsername, normalized);
+
+      candidates.push({
+        user_id: identity.user_id,
+        username: identity.username,
+        similarity,
+      });
+    }
+
+    return candidates.sort((a, b) => b.similarity - a.similarity);
+  }
+
+  /**
+   * Calcula similitud Levenshtein normalizada (0-1).
+   */
+  #calculateSimilarity(str1, str2) {
+    if (str1 === str2) {
+      return 1;
+    }
+
+    const maxLen = Math.max(str1.length, str2.length);
+    if (maxLen === 0) {
+      return 1;
+    }
+
+    const distance = levenshteinDistance(str1, str2);
+    return 1 - distance / maxLen;
+  }
+}

--- a/src/shared/string-utils.js
+++ b/src/shared/string-utils.js
@@ -1,0 +1,30 @@
+/**
+ * Calcula la distancia de Levenshtein entre dos strings.
+ * Retorna el número mínimo de ediciones necesarias.
+ */
+export function levenshteinDistance(str1, str2) {
+  const matrix = Array(str2.length + 1)
+    .fill(null)
+    .map(() => Array(str1.length + 1).fill(0));
+
+  for (let i = 0; i <= str1.length; i++) {
+    matrix[0][i] = i;
+  }
+
+  for (let j = 0; j <= str2.length; j++) {
+    matrix[j][0] = j;
+  }
+
+  for (let j = 1; j <= str2.length; j++) {
+    for (let i = 1; i <= str1.length; i++) {
+      const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+      matrix[j][i] = Math.min(
+        matrix[j][i - 1] + 1, // deletion
+        matrix[j - 1][i] + 1, // insertion
+        matrix[j - 1][i - 1] + indicator, // substitution
+      );
+    }
+  }
+
+  return matrix[str2.length][str1.length];
+}

--- a/test/funa-system.test.js
+++ b/test/funa-system.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { IdentityService } from '../src/core/services/IdentityService.js';
+import { CooldownService } from '../src/core/services/CooldownService.js';
+import { FunaService } from '../src/core/services/FunaService.js';
+
+// Crear base de datos en memoria para tests
+function createTestDb() {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+
+  // Ejecutar schema
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE identities (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      platform TEXT NOT NULL,
+      platform_user_id TEXT NOT NULL,
+      username TEXT NOT NULL,
+      display_name TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES users(id),
+      UNIQUE(platform, platform_user_id)
+    );
+
+    CREATE TABLE funa_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_identity_id INTEGER NOT NULL,
+      target_user_id INTEGER NOT NULL,
+      platform TEXT NOT NULL,
+      source_message_id TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (actor_identity_id) REFERENCES identities(id),
+      FOREIGN KEY (target_user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE command_cooldowns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      command_name TEXT NOT NULL,
+      scope_key TEXT NOT NULL,
+      last_used_at DATETIME NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(command_name, scope_key)
+    );
+
+    CREATE TABLE migrations (
+      id INTEGER PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      executed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX idx_identities_user_id ON identities(user_id);
+    CREATE INDEX idx_identities_platform_user_id ON identities(platform, platform_user_id);
+    CREATE INDEX idx_funa_events_target_user_id ON funa_events(target_user_id);
+    CREATE INDEX idx_command_cooldowns_command_name ON command_cooldowns(command_name);
+  `);
+
+  return db;
+}
+
+describe('Funa System', () => {
+  it('IdentityService: crear identidades y encontrar matches', () => {
+    const db = createTestDb();
+    const identityService = new IdentityService({ db });
+
+    // Crear primera identidad
+    const id1 = identityService.getOrCreateIdentity('twitch', 'user123', 'juanperez', 'Juan Perez');
+    expect(id1.id).toBeDefined();
+    expect(id1.username).toBe('juanperez');
+    expect(id1.user_id).toBe(1);
+
+    // Crear segunda identidad (nombre diferente pero similar)
+    const id2 = identityService.getOrCreateIdentity('twitch', 'user456', 'juan_perez', 'Juan P.');
+    // Debe hacer auto-match porque "juan_perez" es similar a "juanperez"
+    expect(id2.user_id).toBe(1);
+
+    // Crear tercera identidad (nombre completamente diferente)
+    const id3 = identityService.getOrCreateIdentity('twitch', 'user789', 'pedrolopez', 'Pedro Lopez');
+    expect(id3.user_id).not.toBe(1);
+
+    db.close();
+  });
+
+  it('IdentityService: búsqueda de usuarios similares', () => {
+    const db = createTestDb();
+    const identityService = new IdentityService({ db, similarityThreshold: 0.75 });
+
+    // Crear varias identidades
+    identityService.getOrCreateIdentity('twitch', 'u1', 'alice', 'Alice');
+    identityService.getOrCreateIdentity('twitch', 'u2', 'alex', 'Alex');
+    identityService.getOrCreateIdentity('twitch', 'u3', 'bob', 'Bob');
+
+    // Buscar similares a "alice"
+    const matches = identityService.findSimilarUsers('alice');
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    expect(matches[0].username).toBe('alice');
+
+    // Buscar similares a "alic" (debería encontrar alice)
+    const fuzzyMatches = identityService.findSimilarUsers('alic');
+    expect(fuzzyMatches.some((m) => m.username === 'alice')).toBe(true);
+
+    db.close();
+  });
+
+  it('IdentityService: crea identidad pendiente para usuario no registrado', () => {
+    const db = createTestDb();
+    const identityService = new IdentityService({ db });
+
+    const unresolved = identityService.getOrCreateUnresolvedIdentity('twitch', 'lcjury');
+
+    expect(unresolved.user_id).toBeDefined();
+    expect(unresolved.platform).toBe('twitch');
+    expect(unresolved.platform_user_id).toBe('unresolved:lcjury');
+    expect(unresolved.username).toBe('lcjury');
+
+    // Segunda invocación debe devolver la misma identidad pendiente.
+    const unresolvedAgain = identityService.getOrCreateUnresolvedIdentity('twitch', 'lcjury');
+    expect(unresolvedAgain.id).toBe(unresolved.id);
+
+    db.close();
+  });
+
+  it('CooldownService: gestión de cooldowns', () => {
+    const db = createTestDb();
+    const cooldownService = new CooldownService({ db });
+
+    // Primer uso: no está en cooldown
+    const check1 = cooldownService.checkCooldown('funa', 'channel123:global');
+    expect(check1.onCooldown).toBe(false);
+
+    // Registrar uso
+    cooldownService.recordUsage('funa', 'channel123:global');
+
+    // Segundo uso inmediato: debe estar en cooldown
+    const check2 = cooldownService.checkCooldown('funa', 'channel123:global');
+    expect(check2.onCooldown).toBe(true);
+    expect(check2.remainingSeconds).toBeGreaterThan(0);
+    expect(check2.remainingSeconds).toBeLessThanOrEqual(8); // funa tiene cooldown de 8s
+
+    db.close();
+  });
+
+  it('FunaService: registro y conteo de funas', () => {
+    const db = createTestDb();
+    const identityService = new IdentityService({ db });
+    const funaService = new FunaService({ db });
+
+    // Crear identidades
+    const actor = identityService.getOrCreateIdentity('twitch', 'actor1', 'attacker', 'Attacker');
+    const target = identityService.getOrCreateIdentity('twitch', 'target1', 'victim', 'Victim');
+
+    // Registrar funas
+    funaService.recordFunaEvent(actor.id, target.user_id, 'twitch', 'msg1');
+    funaService.recordFunaEvent(actor.id, target.user_id, 'twitch', 'msg2');
+
+    // Verificar conteo
+    const count = funaService.getFunaCount(target.user_id);
+    expect(count).toBe(2);
+
+    // Obtener historial
+    const history = funaService.getFunaHistory(target.user_id);
+    expect(history.length).toBe(2);
+    expect(history[0].actor_username).toBe('attacker');
+
+    db.close();
+  });
+
+  it('FunaService: estadísticas de funas', () => {
+    const db = createTestDb();
+    const identityService = new IdentityService({ db });
+    const funaService = new FunaService({ db });
+
+    // Crear usuarios
+    const actor1 = identityService.getOrCreateIdentity('twitch', 'a1', 'alice', 'Alice');
+    const target1 = identityService.getOrCreateIdentity('twitch', 't1', 'bob', 'Bob');
+    const target2 = identityService.getOrCreateIdentity('twitch', 't2', 'charlie', 'Charlie');
+
+    // Generar funas
+    funaService.recordFunaEvent(actor1.id, target1.user_id, 'twitch', 'msg');
+    funaService.recordFunaEvent(actor1.id, target1.user_id, 'twitch', 'msg');
+    funaService.recordFunaEvent(actor1.id, target2.user_id, 'twitch', 'msg');
+
+    // Obtener estadísticas
+    const stats = funaService.getFunaStats();
+    expect(stats.mostFunedUsers.length).toBeGreaterThan(0);
+    expect(stats.topFuners.length).toBeGreaterThan(0);
+
+    // Bob debe estar como más funado
+    const bobStats = stats.mostFunedUsers.find((u) => u.usernames.includes('bob'));
+    expect(bobStats.funa_count).toBe(2);
+
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add SQLite infrastructure with migrations and local DB ignores
- implement identity, cooldown, and funa domain services
- add Twitch `funa` command and wire services in application startup
- add tests and documentation for manual usage and architecture

## Commit breakdown
1. `feat(db): add sqlite infrastructure and migrations`
2. `feat(identity): add identity matching, cooldown and funa services`
3. `feat(twitch): add funa command and app wiring`
4. `test(docs): add funa tests and usage documentation`

## Validation
- `npm run lint`
- `npm test`
